### PR TITLE
Add minimal sound effects

### DIFF
--- a/components/character-selection.tsx
+++ b/components/character-selection.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect } from "react"
 import { Button } from "@/components/ui/button"
+import { playSound } from "@/lib/sound"
 import { ChevronLeft, ChevronRight } from "lucide-react"
 import type { Character } from "@/app/page"
 
@@ -72,6 +73,7 @@ export default function CharacterSelection({ onBack, onSelect }: CharacterSelect
     if (isTransitioning) return
     setIsTransitioning(true)
     setSelectedIndex((prev) => Math.min(prev + 1, characters.length - 1))
+    playSound("click")
     setTimeout(() => setIsTransitioning(false), 300)
   }
 
@@ -79,6 +81,7 @@ export default function CharacterSelection({ onBack, onSelect }: CharacterSelect
     if (isTransitioning) return
     setIsTransitioning(true)
     setSelectedIndex((prev) => Math.max(prev - 1, 0))
+    playSound("click")
     setTimeout(() => setIsTransitioning(false), 300)
   }
 
@@ -96,7 +99,10 @@ export default function CharacterSelection({ onBack, onSelect }: CharacterSelect
     <div className="flex flex-col items-center w-full h-screen bg-gradient-to-b from-purple-900 to-black px-4 py-8">
       <div className="w-full max-w-4xl">
         <Button
-          onClick={onBack}
+          onClick={() => {
+            playSound("click")
+            onBack()
+          }}
           variant="outline"
           className="mb-6 font-pixel bg-black text-white border-cyan-500 hover:bg-cyan-950 pixel-border"
         >
@@ -142,7 +148,10 @@ export default function CharacterSelection({ onBack, onSelect }: CharacterSelect
                   </div>
 
                   <Button
-                    onClick={() => onSelect(character)}
+                    onClick={() => {
+                      playSound("click")
+                      onSelect(character)
+                    }}
                     className="w-full bg-cyan-600 hover:bg-cyan-500 text-white font-pixel text-sm pixel-border"
                   >
                     ELEGIR
@@ -153,7 +162,10 @@ export default function CharacterSelection({ onBack, onSelect }: CharacterSelect
           </div>
 
           <button
-            onClick={handlePrev}
+            onClick={() => {
+              playSound("click")
+              handlePrev()
+            }}
             disabled={selectedIndex === 0 || isTransitioning}
             className={`absolute left-0 top-1/2 -translate-y-1/2 bg-black p-2 rounded-full ${
               selectedIndex === 0 ? "opacity-30 cursor-not-allowed" : "opacity-100"
@@ -163,7 +175,10 @@ export default function CharacterSelection({ onBack, onSelect }: CharacterSelect
           </button>
 
           <button
-            onClick={handleNext}
+            onClick={() => {
+              playSound("click")
+              handleNext()
+            }}
             disabled={selectedIndex === characters.length - 1 || isTransitioning}
             className={`absolute right-0 top-1/2 -translate-y-1/2 bg-black p-2 rounded-full ${
               selectedIndex === characters.length - 1 ? "opacity-30 cursor-not-allowed" : "opacity-100"
@@ -180,7 +195,10 @@ export default function CharacterSelection({ onBack, onSelect }: CharacterSelect
               className={`w-3 h-3 mx-1 rounded-full cursor-pointer ${
                 selectedIndex === index ? "bg-cyan-500" : "bg-gray-700"
               }`}
-              onClick={() => setSelectedIndex(index)}
+              onClick={() => {
+                playSound("click")
+                setSelectedIndex(index)
+              }}
             />
           ))}
         </div>

--- a/components/main-menu.tsx
+++ b/components/main-menu.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react"
 import { Button } from "@/components/ui/button"
+import { playSound } from "@/lib/sound"
 
 interface MainMenuProps {
   onStart: () => void
@@ -42,7 +43,10 @@ export default function MainMenu({ onStart, onShowControls, onShowCredits }: Mai
         <h1 className="text-5xl font-pixel text-center text-yellow-400 mb-8 pixel-text glow-text">PRESIDENCIA 20XX</h1>
 
         <Button
-          onClick={onStart}
+          onClick={() => {
+            playSound("click")
+            onStart()
+          }}
           className={`bg-purple-700 hover:bg-purple-600 text-white font-pixel text-xl w-64 h-16 mb-6 pixel-border neon-border`}
           style={{
             boxShadow: `0 0 ${10 + glowIntensity * 20}px ${5 + glowIntensity * 10}px rgba(168, 85, 247, ${0.4 + glowIntensity * 0.6})`,
@@ -55,7 +59,10 @@ export default function MainMenu({ onStart, onShowControls, onShowCredits }: Mai
 
         <div className="flex gap-4">
           <Button
-            onClick={onShowCredits}
+            onClick={() => {
+              playSound("click")
+              onShowCredits()
+            }}
             variant="outline"
             className="font-pixel bg-black text-white border-cyan-500 hover:bg-cyan-950 pixel-border"
           >
@@ -63,7 +70,10 @@ export default function MainMenu({ onStart, onShowControls, onShowCredits }: Mai
           </Button>
 
           <Button
-            onClick={onShowControls}
+            onClick={() => {
+              playSound("click")
+              onShowControls()
+            }}
             variant="outline"
             className="font-pixel bg-black text-white border-cyan-500 hover:bg-cyan-950 pixel-border"
           >

--- a/components/presidential-office.tsx
+++ b/components/presidential-office.tsx
@@ -17,6 +17,7 @@ import ParticleSystem, {
 } from "@/components/particle-system"
 import NewsTV from "@/components/news-tv"
 import AmmoCounter from "@/components/ammo-counter"
+import { playSound } from "@/lib/sound"
 
 // ===== INTERFACES Y TIPOS =====
 // Definimos todas las estructuras de datos que usa el juego
@@ -323,11 +324,7 @@ export default function PresidentialOffice({ character, onBack }: PresidentialOf
   }, [])
 
   // ===== SISTEMA DE SONIDO =====
-  // Simula efectos de sonido (en una implementación real usaríamos archivos de audio)
-  const playSound = useCallback((soundType: string) => {
-    console.log(`🔊 Playing sound: ${soundType}`)
-    // En una implementación real, aquí cargaríamos y reproduciríamos archivos de audio
-  }, [])
+  // Se utiliza la utilidad playSound definida en lib/sound
 
   // ===== EFECTO DE TEMBLOR DE PANTALLA =====
   // Crea un efecto visual de impacto cuando ocurren explosiones o disparos
@@ -372,7 +369,7 @@ export default function PresidentialOffice({ character, onBack }: PresidentialOf
         return updated
       })
     },
-    [playSound],
+    [],
   )
 
   // ===== VERIFICACIÓN DE LOGROS =====
@@ -493,7 +490,7 @@ export default function PresidentialOffice({ character, onBack }: PresidentialOf
         addParticles(createSparkParticles(position.x, position.y, 3))
       }
     },
-    [currentWeapon, canSwitchWeapon, isReloading, playSound, addParticles, position],
+    [currentWeapon, canSwitchWeapon, isReloading, addParticles, position],
   )
 
   // ===== SISTEMA DE DISPARO =====
@@ -617,7 +614,6 @@ export default function PresidentialOffice({ character, onBack }: PresidentialOf
     activeEvent,
     isPaused,
     isReloading,
-    playSound,
     triggerScreenShake,
     addParticles,
   ])
@@ -708,7 +704,7 @@ export default function PresidentialOffice({ character, onBack }: PresidentialOf
     setGameStats((prev) => ({ ...prev, explosionsCreated: prev.explosionsCreated + alienCount }))
     playSound("alien_spawn")
     triggerScreenShake(8)
-  }, [nextAlienId, playSound, addParticles, triggerScreenShake])
+  }, [nextAlienId, addParticles, triggerScreenShake])
 
   // ===== SISTEMA DE RECOLECCIÓN DE ITEMS =====
   // Verifica si el jugador está cerca de algún item para recogerlo
@@ -740,7 +736,7 @@ export default function PresidentialOffice({ character, onBack }: PresidentialOf
         }
       }
     })
-  }, [position, droppedItems, updateStats, playSound, addParticles])
+  }, [position, droppedItems, updateStats, addParticles])
 
   // ===== LOOP PRINCIPAL DEL JUEGO =====
   // El corazón del juego que se ejecuta 60 veces por segundo
@@ -986,7 +982,7 @@ export default function PresidentialOffice({ character, onBack }: PresidentialOf
       setGameStats((prev) => ({ ...prev, ministersSpokenTo: prev.ministersSpokenTo + 1 }))
       playSound("dialog_open")
     },
-    [isPaused, activeEvent, playSound, addParticles],
+    [isPaused, activeEvent, addParticles],
   )
 
   // ===== ACCIONES DE DIÁLOGO =====
@@ -1026,7 +1022,7 @@ export default function PresidentialOffice({ character, onBack }: PresidentialOf
         }),
       )
     },
-    [updateStats, playSound, addParticles, npcs],
+    [updateStats, addParticles, npcs],
   )
 
   // ===== REINICIO DEL JUEGO =====
@@ -1077,7 +1073,7 @@ export default function PresidentialOffice({ character, onBack }: PresidentialOf
     setGameStats((prev) => ({ ...prev, aliensKilled: 0, explosionsCreated: 0, dataChipsCollected: 0 }))
     setIsPaused(false)
     playSound("game_reset")
-  }, [playSound])
+  }, [])
 
   // ===== UTILIDAD DE FORMATO DE TIEMPO =====
   const formatTime = (ms: number) => {

--- a/lib/sound.ts
+++ b/lib/sound.ts
@@ -1,0 +1,50 @@
+export type SoundType =
+  | "pistol_shot"
+  | "machinegun_shot"
+  | "weapon_switch"
+  | "reload_start"
+  | "reload_complete"
+  | "alien_spawn"
+  | "alien_hit"
+  | "alien_attack"
+  | "item_collect"
+  | "dialog_open"
+  | "dialog_choice"
+  | "achievement"
+  | "game_reset"
+  | "click"
+  | string
+
+let audioCtx: AudioContext | null = null
+
+const freqMap: Record<string, number> = {
+  pistol_shot: 880,
+  machinegun_shot: 660,
+  weapon_switch: 500,
+  reload_start: 300,
+  reload_complete: 700,
+  alien_spawn: 400,
+  alien_hit: 350,
+  alien_attack: 250,
+  item_collect: 600,
+  dialog_open: 420,
+  dialog_choice: 520,
+  achievement: 750,
+  game_reset: 280,
+  click: 550,
+}
+
+export function playSound(type: SoundType) {
+  if (typeof window === "undefined") return
+  if (!audioCtx) audioCtx = new (window.AudioContext || (window as any).webkitAudioContext)()
+  const frequency = freqMap[type] ?? 440
+  const oscillator = audioCtx.createOscillator()
+  const gain = audioCtx.createGain()
+  oscillator.type = "square"
+  oscillator.frequency.value = frequency
+  gain.gain.value = 0.1
+  oscillator.connect(gain)
+  gain.connect(audioCtx.destination)
+  oscillator.start()
+  oscillator.stop(audioCtx.currentTime + 0.1)
+}


### PR DESCRIPTION
## Summary
- implement basic sound utility using the Web Audio API
- wire `playSound` into the presidential office component
- play sound on main menu and character selection actions

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843b15c50ac832c8e1ec9fe5833af8c