### PR TITLE
Enhance main menu layout and keyboard navigation

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,29 +1,31 @@
-"use client"
+"use client";
 
-import { useState, useEffect } from "react"
-import MainMenu from "@/components/main-menu"
-import CharacterSelection from "@/components/character-selection"
-import PresidentialOffice from "@/components/presidential-office"
-import ControlsModal from "@/components/controls-modal"
-import CreditsModal from "@/components/credits-modal"
+import { useState, useEffect } from "react";
+import MainMenu from "@/components/main-menu";
+import CharacterSelection from "@/components/character-selection";
+import PresidentialOffice from "@/components/presidential-office";
+import ControlsModal from "@/components/controls-modal";
+import CreditsModal from "@/components/credits-modal";
 
-export type GameScreen = "main-menu" | "character-selection" | "office"
+export type GameScreen = "main-menu" | "character-selection" | "office";
 export type Character = {
-  id: string
-  name: string
-  quote: string
-  ability: string
-  abilityIcon: string
-  passive: string
-  passiveIcon: string
-  sprite: string
-}
+  id: string;
+  name: string;
+  quote: string;
+  ability: string;
+  abilityIcon: string;
+  passive: string;
+  passiveIcon: string;
+  sprite: string;
+};
 
 export default function Home() {
-  const [currentScreen, setCurrentScreen] = useState<GameScreen>("main-menu")
-  const [selectedCharacter, setSelectedCharacter] = useState<Character | null>(null)
-  const [showControls, setShowControls] = useState(false)
-  const [showCredits, setShowCredits] = useState(false)
+  const [currentScreen, setCurrentScreen] = useState<GameScreen>("main-menu");
+  const [selectedCharacter, setSelectedCharacter] = useState<Character | null>(
+    null,
+  );
+  const [showControls, setShowControls] = useState(false);
+  const [showCredits, setShowCredits] = useState(false);
 
   // Preload images
   useEffect(() => {
@@ -35,16 +37,16 @@ export default function Home() {
       "/characters/chiquito-tapon.png",
       "/backgrounds/casa-rosada.png",
       "/backgrounds/office-floor.png",
-    ]
+    ];
 
     images.forEach((src) => {
-      const img = new Image()
-      img.src = src
-    })
-  }, [])
+      const img = new Image();
+      img.src = src;
+    });
+  }, []);
 
   return (
-    <main className="w-full h-screen overflow-hidden bg-black">
+    <main className="w-full min-h-screen overflow-y-auto bg-black">
       {currentScreen === "main-menu" && (
         <MainMenu
           onStart={() => setCurrentScreen("character-selection")}
@@ -57,18 +59,21 @@ export default function Home() {
         <CharacterSelection
           onBack={() => setCurrentScreen("main-menu")}
           onSelect={(character) => {
-            setSelectedCharacter(character)
-            setCurrentScreen("office")
+            setSelectedCharacter(character);
+            setCurrentScreen("office");
           }}
         />
       )}
 
       {currentScreen === "office" && selectedCharacter && (
-        <PresidentialOffice character={selectedCharacter} onBack={() => setCurrentScreen("character-selection")} />
+        <PresidentialOffice
+          character={selectedCharacter}
+          onBack={() => setCurrentScreen("character-selection")}
+        />
       )}
 
       {showControls && <ControlsModal onClose={() => setShowControls(false)} />}
       {showCredits && <CreditsModal onClose={() => setShowCredits(false)} />}
     </main>
-  )
+  );
 }

--- a/components/main-menu.tsx
+++ b/components/main-menu.tsx
@@ -1,28 +1,65 @@
-"use client"
+"use client";
 
-import { useState, useEffect } from "react"
-import { Button } from "@/components/ui/button"
+import { useState, useEffect, useRef } from "react";
+import { Button } from "@/components/ui/button";
 
 interface MainMenuProps {
-  onStart: () => void
-  onShowControls: () => void
-  onShowCredits: () => void
+  onStart: () => void;
+  onShowControls: () => void;
+  onShowCredits: () => void;
 }
 
-export default function MainMenu({ onStart, onShowControls, onShowCredits }: MainMenuProps) {
-  const [glowIntensity, setGlowIntensity] = useState(0)
+export default function MainMenu({
+  onStart,
+  onShowControls,
+  onShowCredits,
+}: MainMenuProps) {
+  const [glowIntensity, setGlowIntensity] = useState(0);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const buttonRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  const menuItems = [
+    { label: "START", action: onStart },
+    { label: "Créditos", action: onShowCredits },
+    { label: "Controles", action: onShowControls },
+  ];
+
+  // Focus selected button when index changes
+  useEffect(() => {
+    buttonRefs.current[selectedIndex]?.focus();
+  }, [selectedIndex]);
+
+  // Keyboard navigation
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "ArrowDown" || e.key.toLowerCase() === "s") {
+        e.preventDefault();
+        setSelectedIndex((prev) => (prev + 1) % menuItems.length);
+      } else if (e.key === "ArrowUp" || e.key.toLowerCase() === "w") {
+        e.preventDefault();
+        setSelectedIndex(
+          (prev) => (prev - 1 + menuItems.length) % menuItems.length,
+        );
+      } else if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        menuItems[selectedIndex].action();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [selectedIndex, menuItems]);
 
   // Pulsating glow effect
   useEffect(() => {
     const interval = setInterval(() => {
       setGlowIntensity((prev) => {
-        const newValue = prev + 0.05
-        return newValue > 1 ? 0 : newValue
-      })
-    }, 50)
+        const newValue = prev + 0.05;
+        return newValue > 1 ? 0 : newValue;
+      });
+    }, 50);
 
-    return () => clearInterval(interval)
-  }, [])
+    return () => clearInterval(interval);
+  }, []);
 
   return (
     <div className="relative w-full h-full flex flex-col items-center justify-center overflow-hidden">
@@ -30,47 +67,54 @@ export default function MainMenu({ onStart, onShowControls, onShowCredits }: Mai
       <div className="absolute inset-0 bg-black">
         <div className="absolute inset-0 bg-[url('/backgrounds/casa-rosada.png')] bg-cover bg-center opacity-30 blur-sm">
           {/* Chaos elements */}
-          <div className="absolute top-1/4 left-1/4 text-4xl animate-float">👽</div>
-          <div className="absolute top-1/3 right-1/3 text-4xl animate-float-delay">🔥</div>
-          <div className="absolute bottom-1/4 right-1/4 text-4xl animate-float-alt">💸</div>
-          <div className="absolute bottom-1/3 left-1/3 text-4xl animate-float-delay-alt">📰</div>
+          <div className="absolute top-1/4 left-1/4 text-4xl animate-float">
+            👽
+          </div>
+          <div className="absolute top-1/3 right-1/3 text-4xl animate-float-delay">
+            🔥
+          </div>
+          <div className="absolute bottom-1/4 right-1/4 text-4xl animate-float-alt">
+            💸
+          </div>
+          <div className="absolute bottom-1/3 left-1/3 text-4xl animate-float-delay-alt">
+            📰
+          </div>
         </div>
       </div>
 
       {/* Content */}
       <div className="relative z-10 w-full max-w-md flex flex-col items-center px-4">
-        <h1 className="text-5xl font-pixel text-center text-yellow-400 mb-8 pixel-text glow-text">PRESIDENCIA 20XX</h1>
+        <h1 className="text-5xl font-pixel text-center text-yellow-400 mb-8 pixel-text glow-text">
+          PRESIDENCIA 20XX
+        </h1>
 
-        <Button
-          onClick={onStart}
-          className={`bg-purple-700 hover:bg-purple-600 text-white font-pixel text-xl w-64 h-16 mb-6 pixel-border neon-border`}
-          style={{
-            boxShadow: `0 0 ${10 + glowIntensity * 20}px ${5 + glowIntensity * 10}px rgba(168, 85, 247, ${0.4 + glowIntensity * 0.6})`,
-          }}
-        >
-          START
-        </Button>
-
-        <p className="text-center font-pixel text-cyan-300 mb-12">Elegí tu destino. O crealo.</p>
-
-        <div className="flex gap-4">
+        {menuItems.map((item, index) => (
           <Button
-            onClick={onShowCredits}
-            variant="outline"
-            className="font-pixel bg-black text-white border-cyan-500 hover:bg-cyan-950 pixel-border"
+            key={item.label}
+            ref={(el) => (buttonRefs.current[index] = el)}
+            onClick={item.action}
+            variant={index === 0 ? "default" : "outline"}
+            className={`font-pixel text-xl w-64 h-16 mb-6 pixel-border ${
+              index === 0
+                ? "bg-purple-700 hover:bg-purple-600 text-white neon-border"
+                : "bg-black text-white border-cyan-500 hover:bg-cyan-950"
+            } ${selectedIndex === index ? "ring-2 ring-yellow-400" : ""}`}
+            style={
+              index === 0
+                ? {
+                    boxShadow: `0 0 ${10 + glowIntensity * 20}px ${5 + glowIntensity * 10}px rgba(168, 85, 247, ${0.4 + glowIntensity * 0.6})`,
+                  }
+                : undefined
+            }
           >
-            Créditos
+            {item.label}
           </Button>
+        ))}
 
-          <Button
-            onClick={onShowControls}
-            variant="outline"
-            className="font-pixel bg-black text-white border-cyan-500 hover:bg-cyan-950 pixel-border"
-          >
-            Controles
-          </Button>
-        </div>
+        <p className="text-center font-pixel text-cyan-300 mt-4">
+          Elegí tu destino. O crealo.
+        </p>
       </div>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- allow page to scroll vertically to prevent truncated menu
- add keyboard navigation for the main menu
- keep button focus synced with selected item

## Testing
- `npx prettier -w components/main-menu.tsx app/page.tsx`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843b14562bc832c854a3ae59f12004f